### PR TITLE
Update argument handling

### DIFF
--- a/SerialDisk/Comm/Serial.cs
+++ b/SerialDisk/Comm/Serial.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO.Ports;
 using AtariST.SerialDisk.Storage;
 using AtariST.SerialDisk.Models;
@@ -15,7 +15,7 @@ namespace AtariST.SerialDisk.Comm
 
         public ReceiverState State { get; set; }
 
-        public bool ReceiverContinue = true;
+        private bool ReceiverContinue = true;
 
         private int ReceivedDataCounter = 0;
 
@@ -43,11 +43,11 @@ namespace AtariST.SerialDisk.Comm
             ReceiveEndMagic
         };
 
-        public Serial(Settings applicationSettings, Disk sourceDisk)
+        public Serial(Settings applicationSettings, Disk localDisk)
         {
             verbosity = applicationSettings.Verbosity;
 
-            disk = sourceDisk;
+            disk = localDisk;
 
             State = ReceiverState.ReceiveStartMagic;
 
@@ -71,7 +71,7 @@ namespace AtariST.SerialDisk.Comm
             ReceiverContinue = false;
         }
 
-        public void SerialDataReceiver(string localDirectoryName, int readTimeout, int verbosity) //Settings applicationSettings)
+        public void SerialDataReceiver(string localDirectoryName, int readTimeout, int verbosity)
         {
             DateTime TransferEndDateTime = DateTime.Now;
             DateTime TransferStartDateTime = DateTime.Now;

--- a/SerialDisk/Models/Settings.cs
+++ b/SerialDisk/Models/Settings.cs
@@ -6,19 +6,19 @@ namespace AtariST.SerialDisk.Models
     {
         public SerialPortSettings SerialSettings { get; set; }
 
-        public int Verbosity { get; set; }
-        public string LocalDirectoryName { get; set; }
-        public int DiskSizeMB { get; set; }
+        public int Verbosity { get; set; } = 0;
+        public string LocalDirectoryName { get; set; } = ".";
+        public int DiskSizeMB { get; set; } = 32;
     }
 
     public class SerialPortSettings
     {
-        public string PortName { get; set; }
-        public Handshake Handshake { get; set; }
-        public int BaudRate { get; set; }
-        public int DataBits { get; set; }
-        public StopBits StopBits { get; set; }
-        public Parity Parity { get; set; }
-        public int Timeout { get; set; }
+        public string PortName { get; set; } = "COM1";
+        public Handshake Handshake { get; set; } = Handshake.None;
+        public int BaudRate { get; set; } = 9600;
+        public int DataBits { get; set; } = 8;
+        public StopBits StopBits { get; set; } = StopBits.One;
+        public Parity Parity { get; set; } = Parity.None;
+        public int Timeout { get; set; } = 100;
     }
 }

--- a/SerialDisk/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/SerialDisk/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <PublishDir>bin\Debug\netcoreapp2.1\publish\</PublishDir>
+    <SelfContained>false</SelfContained>
+    <_IsPortable>true</_IsPortable>
+  </PropertyGroup>
+</Project>

--- a/SerialDisk/Utilities/Parameters.cs
+++ b/SerialDisk/Utilities/Parameters.cs
@@ -1,130 +1,160 @@
 ﻿using AtariST.SerialDisk.Models;
-using System.Collections.Specialized;
-using System.IO;
+using AtariST.SerialDisk.Shared;
+using System;
 using System.IO.Ports;
 
 namespace AtariST.SerialDisk.Utilities
 {
     public static class Parameters
     {
+        private const string localDirectoryParam = "--local-directory";
+        private const string diskSizeParam = "--disk-size";
+        private const string portParam = "--port";
+        private const string baudRateParam = "--baud-rate";
+        private const string stopBitsParam = "--stop-bits";
+        private const string dataBitsParam = "--data-bits";
+        private const string parityParam = "--parity";
+        private const string flowControlParam = "--handshake";
+        private const string verbosityParam = "--verbosity";
+
         public static Settings ParseParameters(string[] arguments)
         {
-            NameValueCollection argumentNameValueCollection = new NameValueCollection();
-
             Settings applicationSettings = new Settings
             {
                 SerialSettings = new SerialPortSettings()
             };
 
-            foreach (string argument in arguments)
+            for (int argindex = 0; argindex < arguments.Length; argindex++)
             {
-                string[] NameValue = argument.Split('=');
-
-                if (NameValue.Length == 2)
-                    argumentNameValueCollection.Add(NameValue[0].ToLower().Trim(), NameValue[1].Trim());
-                else
-                    applicationSettings.LocalDirectoryName = argument.TrimEnd(Path.DirectorySeparatorChar);
+                if (argindex == arguments.Length - 1) SetParameter(localDirectoryParam, arguments[argindex], applicationSettings);
+                else SetParameter(arguments[argindex], arguments[argindex + 1], applicationSettings);
             }
-
-            applicationSettings.DiskSizeMB = argumentNameValueCollection["--disk-size"] == null ? 32 : int.Parse(argumentNameValueCollection["--disk-size"]);
-
-            if (string.IsNullOrEmpty(applicationSettings.LocalDirectoryName)) applicationSettings.LocalDirectoryName = ".";
-
-            applicationSettings.SerialSettings.PortName = argumentNameValueCollection["--port"];
-
-            applicationSettings.SerialSettings.Timeout = 100;
-
-            if (argumentNameValueCollection["--baud-rate"] == null)
-                applicationSettings.SerialSettings.BaudRate = 19200;
-            else
-                applicationSettings.SerialSettings.BaudRate = int.Parse(argumentNameValueCollection["--baud-rate"]);
-
-            switch (argumentNameValueCollection["--parity"]?.ToLowerInvariant())
-            {
-                case null:
-                case "n":
-                    applicationSettings.SerialSettings.Parity = Parity.None;
-
-                    break;
-
-                case "e":
-                    applicationSettings.SerialSettings.Parity = Parity.Even;
-
-                    break;
-
-                case "m":
-                    applicationSettings.SerialSettings.Parity = Parity.Mark;
-
-                    break;
-
-                case "o":
-                    applicationSettings.SerialSettings.Parity = Parity.Odd;
-
-                    break;
-
-                case "s":
-                    applicationSettings.SerialSettings.Parity = Parity.Space;
-
-                    break;
-            }
-
-            switch (argumentNameValueCollection["--stop-bits"]?.ToLowerInvariant())
-            {
-                case null:
-                case "1":
-                    applicationSettings.SerialSettings.StopBits = StopBits.One;
-
-                    break;
-
-                case "1.5":
-                    applicationSettings.SerialSettings.StopBits = StopBits.OnePointFive;
-
-                    break;
-
-                case "2":
-                    applicationSettings.SerialSettings.StopBits = StopBits.Two;
-
-                    break;
-
-                case "n":
-                    applicationSettings.SerialSettings.StopBits = StopBits.None;
-
-                    break;
-            }
-
-            if (argumentNameValueCollection["--data-bits"] == null)
-                applicationSettings.SerialSettings.DataBits = 8;
-            else
-                applicationSettings.SerialSettings.DataBits = int.Parse(argumentNameValueCollection["--data-bits"]);
-
-            switch (argumentNameValueCollection["--handshake"]?.ToLowerInvariant())
-            {
-                case null:
-                case "none":
-                    applicationSettings.SerialSettings.Handshake = Handshake.None;
-
-                    break;
-
-                case "rts":
-                    applicationSettings.SerialSettings.Handshake = Handshake.RequestToSend;
-
-                    break;
-
-                case "rts_xon_xoff":
-                    applicationSettings.SerialSettings.Handshake = Handshake.RequestToSendXOnXOff;
-
-                    break;
-
-                case "xon_xoff":
-                    applicationSettings.SerialSettings.Handshake = Handshake.XOnXOff;
-
-                    break;
-            }
-
-            if (argumentNameValueCollection["--verbosity"] != null)
-                applicationSettings.Verbosity = int.Parse(argumentNameValueCollection["--verbosity"]);
 
             return applicationSettings;
+        }
+
+        private static void SetParameter(string argumentName, string argumentValue, Settings applicationSettings)
+        {
+            switch (argumentName.ToLowerInvariant())
+            {
+                case localDirectoryParam:
+                    applicationSettings.LocalDirectoryName = argumentValue;
+                    break;
+
+                case verbosityParam:
+                    applicationSettings.Verbosity = ParseIntParam(argumentName, argumentValue);
+                    break;
+
+                case diskSizeParam:
+                    applicationSettings.DiskSizeMB = ParseIntParam(argumentName, argumentValue);
+                    break;
+
+                case portParam:
+                    applicationSettings.SerialSettings.PortName = argumentValue;
+                    break;
+
+                case baudRateParam:
+                    applicationSettings.SerialSettings.BaudRate = ParseIntParam(argumentName, argumentValue);
+                    break;
+
+                case dataBitsParam:
+                    applicationSettings.SerialSettings.DataBits = ParseIntParam(argumentName, argumentValue);
+                    break;
+
+                case parityParam:
+                    switch(argumentValue)
+                    {
+                        case "n":
+                            applicationSettings.SerialSettings.Parity = Parity.None;
+                            break;
+
+                        case "e":
+                            applicationSettings.SerialSettings.Parity = Parity.Even;
+                            break;
+
+                        case "m":
+                            applicationSettings.SerialSettings.Parity = Parity.Mark;
+                            break;
+
+                        case "o":
+                            applicationSettings.SerialSettings.Parity = Parity.Odd;
+                            break;
+
+                        case "s":
+                            applicationSettings.SerialSettings.Parity = Parity.Space;
+                            break;
+
+                        default:
+                            ArgumentException argEx = new ArgumentException($"{argumentName} value is invalid.");
+                            Error.Log(argEx, argEx.Message);
+                            throw argEx;
+                    }
+                    break;
+
+                case stopBitsParam:
+                    switch (argumentValue)
+                    {
+                        case "1":
+                            applicationSettings.SerialSettings.StopBits = StopBits.One;
+                            break;
+
+                        case "1.5":
+                            applicationSettings.SerialSettings.StopBits = StopBits.OnePointFive;
+                            break;
+
+                        case "2":
+                            applicationSettings.SerialSettings.StopBits = StopBits.Two;
+                            break;
+
+                        case "n":
+                            applicationSettings.SerialSettings.StopBits = StopBits.None;
+                            break;
+                        default:
+                            ArgumentException argEx = new ArgumentException($"{argumentName} value is invalid.");
+                            Error.Log(argEx, argEx.Message);
+                            throw argEx;
+                    }
+                    break;
+
+                case flowControlParam:
+                    switch (argumentValue)
+                    {
+                        case "none":
+                            applicationSettings.SerialSettings.Handshake = Handshake.None;
+                            break;
+
+                        case "rts":
+                            applicationSettings.SerialSettings.Handshake = Handshake.RequestToSend;
+                            break;
+
+                        case "rts-xon-xoff":
+                            applicationSettings.SerialSettings.Handshake = Handshake.RequestToSendXOnXOff;
+                            break;
+
+                        case "xon-xoff":
+                            applicationSettings.SerialSettings.Handshake = Handshake.XOnXOff;
+                            break;
+                        default:
+                            ArgumentException argEx = new ArgumentException($"{argumentName} value is invalid.");
+                            Error.Log(argEx, argEx.Message);
+                            throw argEx;
+                    }
+                    break;
+            }        
+        }
+
+        private static int ParseIntParam(string argumentName, string argumentValue)
+        {
+            try
+            {
+                return int.Parse(argumentValue);
+            }
+
+            catch (FormatException formatEx)
+            {
+                Error.Log(formatEx, $"{argumentName} must be a number.");
+                throw formatEx;
+            }
         }
     }
 }


### PR DESCRIPTION
Note that parameter name-value pairs are now separated by spaces rather than =.